### PR TITLE
fix: don't use stdout for logs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,10 +1,7 @@
 import { readJSON } from './util.js';
-import Log from './log.js';
 import runTasks from './index.js';
 
 const pkg = readJSON(new URL('../package.json', import.meta.url));
-
-const log = new Log();
 
 const helpText = `Release It! v${pkg.version}
 
@@ -27,10 +24,10 @@ const helpText = `Release It! v${pkg.version}
 For more details, please see https://github.com/release-it/release-it`;
 
 /** @internal */
-export const version = () => log.log(`v${pkg.version}`);
+export const version = () => console.log(`v${pkg.version}`);
 
 /** @internal */
-export const help = () => log.log(helpText);
+export const help = () => console.log(helpText);
 
 export default async options => {
   if (options.version) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -16,7 +16,7 @@ class Logger {
   }
 
   log(...args) {
-    console.log(...args);
+    console.error(...args);
   }
 
   error(...args) {


### PR DESCRIPTION
Don't use console.log for logging, as it outputs to stdout instead of stderr.